### PR TITLE
update install instructions, startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ This code was written and tested with a Raspberry Pi Zero W.
 Assuming python3 and pip3 are installed, install the following **as root**. Do not use a virtualenv!
 
 ```bash
-sudo pip3 install gatt pyyaml apscheduler qhue python-nest
-sudo apt-get install python3-dbus
+sudo pip3 install -r requirements.txt
 ```
 
 Make sure your Turn Touch is disconnected **and unpaired** from any other devices, then run:

--- a/monitor.py
+++ b/monitor.py
@@ -10,11 +10,6 @@ import subprocess
 
 from controllers.base_controller import BaseController
 
-logging.basicConfig(filename='/var/log/turntouch.log',
-        filemode='a',
-        format='%(asctime)s,%(msecs)d %(name)s %(levelname)s %(message)s',
-        datefmt='%H:%M:%S',
-        level=logging.INFO)
 
 logger = logging.getLogger('monitor')
 
@@ -161,6 +156,12 @@ if __name__ == '__main__':
 
     if args.print:
         print_log = True
+    else:
+        logging.basicConfig(filename='/var/log/turntouch.log',
+            filemode='a',
+            format='%(asctime)s,%(msecs)d %(name)s %(levelname)s %(message)s',
+            datefmt='%H:%M:%S',
+            level=logging.INFO)
 
     if args.list:
         print("Controllers:")
@@ -209,3 +210,4 @@ if __name__ == '__main__':
             log("Trying to connect to {} at {}...".format(c['name'], c['mac']))
             device.connect()
         manager.run()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+gatt
+pyyaml
+apscheduler
+qhue
+python-nest
+dbus-python


### PR DESCRIPTION
- add a requirements.txt and change the install to point that way
- apt installs aren't needed, do it through pip
- move logging setup to main. Lets it start properly with `--print` (meaning logging isn't being used)

Hopefully I'll have more headed your way.